### PR TITLE
Added file detection for *.SVG files when working with folders

### DIFF
--- a/lib/svgo/coa.js
+++ b/lib/svgo/coa.js
@@ -16,6 +16,7 @@ var FS = require('fs'),
     decodeSVGDatauri = require('./tools.js').decodeSVGDatauri,
     checkIsDir = require('./tools.js').checkIsDir,
     regSVGFile = /\.svg$/,
+    regSVGFileCapital = /\.SVG$/,
     noop = () => {},
     svgo;
 
@@ -413,7 +414,12 @@ function getFilesDescriptions(config, dir, files, output) {
         .map(name => ({
             inputPath: PATH.resolve(dir, name),
             outputPath: PATH.resolve(output, name),
-        }));
+        })).concat(files
+            .filter(name => regSVGFileCapital.test(name))
+            .map(name => ({
+                inputPath: PATH.resolve(dir, name),
+                outputPath: PATH.resolve(output, name),
+            })));
 
     return config.recursive ?
         [].concat(


### PR DESCRIPTION
Currently, files named *.SVG are not being detected under Windows because of the case-sensitivity. This commit includes these in addition to *.svg files.